### PR TITLE
refactor: remove @Suppress("UnstableApiUsage") annotations for cleane…

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/VanillaPlus.main.iml" filepath="$PROJECT_DIR$/.idea/modules/VanillaPlus.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/vanillaplus.iml" filepath="$PROJECT_DIR$/.idea/modules/vanillaplus.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/vanillaplus.main.iml" filepath="$PROJECT_DIR$/.idea/modules/vanillaplus.main.iml" />
     </modules>
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ version = "1.14.0"
 description = "Minecraft plugin that enhances the base gameplay."
 
 var author: String = "Xodium"
-var apiVersion: String = "1.21.6"
+var apiVersion: String = "1.21.7"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/org/xodium/vanillaplus/data/CommandData.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/data/CommandData.kt
@@ -15,7 +15,6 @@ import io.papermc.paper.command.brigadier.CommandSourceStack
  * @property aliases A list of aliases for the command.
  */
 data class CommandData(
-    @Suppress("UnstableApiUsage")
     val commands: Collection<LiteralArgumentBuilder<CommandSourceStack>>,
     val description: String,
     val aliases: List<String>

--- a/src/main/kotlin/org/xodium/vanillaplus/managers/ModuleManager.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/managers/ModuleManager.kt
@@ -80,7 +80,6 @@ object ModuleManager {
         }
         //TODO: check if we can make this more compact.
         commandsToRegister.takeIf { it.isNotEmpty() }?.let {
-            @Suppress("UnstableApiUsage")
             instance.lifecycleManager.registerEventHandler(LifecycleEvents.COMMANDS) { event ->
                 it.forEach { commandData ->
                     commandData.commands.forEach { command ->

--- a/src/main/kotlin/org/xodium/vanillaplus/modules/AutoRestartModule.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/modules/AutoRestartModule.kt
@@ -27,7 +27,6 @@ class AutoRestartModule : ModuleInterface<AutoRestartModule.Config> {
 
     override fun enabled(): Boolean = config.enabled
 
-    @Suppress("UnstableApiUsage")
     override fun cmds(): CommandData? {
         return CommandData(
             listOf(

--- a/src/main/kotlin/org/xodium/vanillaplus/modules/BooksModule.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/modules/BooksModule.kt
@@ -24,7 +24,6 @@ class BooksModule : ModuleInterface<BooksModule.Config> {
 
     override fun enabled(): Boolean = config.enabled
 
-    @Suppress("UnstableApiUsage")
     override fun cmds(): CommandData? {
         return CommandData(
             config.books.map { book ->

--- a/src/main/kotlin/org/xodium/vanillaplus/modules/ChatModule.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/modules/ChatModule.kt
@@ -37,7 +37,6 @@ class ChatModule : ModuleInterface<ChatModule.Config> {
 
     override fun enabled(): Boolean = config.enabled
 
-    @Suppress("UnstableApiUsage")
     override fun cmds(): CommandData? {
         return CommandData(
             listOf(

--- a/src/main/kotlin/org/xodium/vanillaplus/modules/InvSearchModule.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/modules/InvSearchModule.kt
@@ -42,7 +42,6 @@ class InvSearchModule : ModuleInterface<InvSearchModule.Config> {
     override fun cmds(): CommandData? {
         return CommandData(
             listOf(
-                @Suppress("UnstableApiUsage")
                 Commands.literal("invsearch")
                     .requires { it.sender.hasPermission(perms()[0]) }
                     .then(
@@ -78,7 +77,6 @@ class InvSearchModule : ModuleInterface<InvSearchModule.Config> {
      * @param ctx The command context containing the command source and arguments.
      * @return An integer indicating the result of the command execution.
      */
-    @Suppress("UnstableApiUsage")
     private fun handleSearch(ctx: CommandContext<CommandSourceStack>): Int {
         val player = ctx.source.sender as? Player ?: return 0
         val materialName = runCatching { StringArgumentType.getString(ctx, "material") }.getOrNull()

--- a/src/main/kotlin/org/xodium/vanillaplus/modules/InvUnloadModule.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/modules/InvUnloadModule.kt
@@ -37,7 +37,6 @@ class InvUnloadModule : ModuleInterface<InvUnloadModule.Config> {
 
     override fun enabled(): Boolean = config.enabled
 
-    @Suppress("UnstableApiUsage")
     override fun cmds(): CommandData? {
         return CommandData(
             listOf(

--- a/src/main/kotlin/org/xodium/vanillaplus/modules/NicknameModule.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/modules/NicknameModule.kt
@@ -28,7 +28,6 @@ class NicknameModule(private val tabListModule: TabListModule) : ModuleInterface
     override fun cmds(): CommandData? {
         return CommandData(
             listOf(
-                @Suppress("UnstableApiUsage")
                 Commands.literal("nickname")
                     .requires { it.sender.hasPermission(perms()[0]) }
                     .executes { ctx -> Utils.tryCatch(ctx) { nickname(it.sender as Player, "") } }

--- a/src/main/kotlin/org/xodium/vanillaplus/modules/TrowelModule.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/modules/TrowelModule.kt
@@ -31,7 +31,6 @@ class TrowelModule : ModuleInterface<TrowelModule.Config> {
 
     override fun enabled(): Boolean = config.enabled
 
-    @Suppress("UnstableApiUsage")
     override fun cmds(): CommandData? {
         return CommandData(
             listOf(

--- a/src/main/kotlin/org/xodium/vanillaplus/utils/Utils.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/utils/Utils.kt
@@ -40,7 +40,6 @@ object Utils {
      * @param action The action to execute, receiving a CommandSourceStack as a parameter.
      * @return Command.SINGLE_SUCCESS after execution.
      */
-    @Suppress("UnstableApiUsage")
     fun tryCatch(ctx: CommandContext<CommandSourceStack>, action: (CommandSourceStack) -> Unit): Int {
         try {
             action(ctx.source)

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,7 +2,7 @@ name: VanillaPlus
 version: ${version}
 main: org.xodium.vanillaplus.VanillaPlus
 description: ${description}
-api-version: 1.21.6
+api-version: 1.21.7
 author: ${author}
 dependencies:
   server:


### PR DESCRIPTION
This pull request includes changes to improve module organization and remove unnecessary code annotations across multiple files. The most important changes involve updating module file paths, removing `@Suppress("UnstableApiUsage")` annotations, and updating the API version in the plugin configuration.

### Module organization updates:
* [`.idea/modules.xml`](diffhunk://#diff-0aae258f1732eac2acd4fcdd1af6d0737b4ec8d233136c3ba7c40b6d49aeda50L5-R6): Updated module file paths to use lowercase naming conventions and added a new module entry for `vanillaplus.main.iml`.

### Code cleanup:
* Removed `@Suppress("UnstableApiUsage")` annotations across various files, including:
  - `src/main/kotlin/org/xodium/vanillaplus/data/CommandData.kt`
  - `src/main/kotlin/org/xodium/vanillaplus/managers/ModuleManager.kt`
  - Multiple module files such as `AutoRestartModule`, `BooksModule`, `ChatModule`, `InvSearchModule`, `InvUnloadModule`, `NicknameModule`, and `TrowelModule`. [[1]](diffhunk://#diff-9827a8fe1102832fe12e1b08eefbe92675fb9a85a56e23512aadcaa715518e5cL30) [[2]](diffhunk://#diff-c013407c41330f8cd472cd72071313b66b71a1ef684a8f9f2c6b00195cbf7559L27) [[3]](diffhunk://#diff-3d952f180a11d2d311f288fba97603637eb22902d23e5e999cccbfcd42c47dabL40) [[4]](diffhunk://#diff-03d7b244d631d42ed98c76a97223553c9c6617b19b5cea2a2a0ff4a3bfb6f5abL45) [[5]](diffhunk://#diff-efe6b51ed7dd4fe1641bbb6f12e0325a8239b5d1db3ea7c649e7e5e0ac552b3bL40) [[6]](diffhunk://#diff-f87283bef0b3d4bcaf92a07238bcbf97d6b34aa64fa128429cb31b9679063fbeL31) [[7]](diffhunk://#diff-413c3d09d6853edc7107de528ad08a065303ff61c806f8999f9b34e6d294719aL34)
  - Utility file `Utils.kt`.

### Plugin configuration update:
* [`src/main/resources/paper-plugin.yml`](diffhunk://#diff-21d9405139b0003df9c66ea4d6f3af8d447c5d1b7b97e5d281f039dd752b7c1bL5-R5): Updated `api-version` from `1.21.6` to `1.21.7`.